### PR TITLE
Add player lookup utility and integrate with draw scraping

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,1 +1,5 @@
-# Tennis Model - Data processing package
+"""Data processing utilities for the tennis model."""
+
+from .player_utils import lookup_player_id
+
+__all__ = ["lookup_player_id"]

--- a/src/data/draw_scraper.py
+++ b/src/data/draw_scraper.py
@@ -1,0 +1,49 @@
+"""Simple utilities for scraping and processing tournament draws."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import sqlite3
+from typing import Iterable, Tuple, List
+
+from .player_utils import lookup_player_id, DB_PATH
+
+logger = logging.getLogger(__name__)
+
+
+def parse_draw_file(path: Path) -> List[Tuple[str, str]]:
+    """Placeholder parser that reads a simple CSV with ``player1,player2`` rows."""
+    matchups = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) >= 2:
+                matchups.append((parts[0], parts[1]))
+    return matchups
+
+
+def convert_matchups_to_ids(
+    matchups: Iterable[Tuple[str, str]],
+    conn: sqlite3.Connection | None = None,
+    manual_map: dict | None = None,
+) -> List[Tuple[str | None, str | None]]:
+    """Convert a list of matchup player name tuples to player id tuples."""
+    manual_map = manual_map or {}
+    close_conn = False
+    if conn is None:
+        conn = sqlite3.connect(DB_PATH)
+        close_conn = True
+
+    results = []
+    for p1_name, p2_name in matchups:
+        p1_first, p1_last = p1_name.split(" ", 1)
+        p2_first, p2_last = p2_name.split(" ", 1)
+        p1_id = lookup_player_id(p1_first, p1_last, conn=conn, manual_map=manual_map)
+        p2_id = lookup_player_id(p2_first, p2_last, conn=conn, manual_map=manual_map)
+        results.append((p1_id, p2_id))
+
+    if close_conn:
+        conn.close()
+
+    return results

--- a/src/data/player_utils.py
+++ b/src/data/player_utils.py
@@ -1,0 +1,89 @@
+import sqlite3
+from pathlib import Path
+import difflib
+import logging
+
+# Default path to the SQLite database
+DB_PATH = Path("data") / "processed" / "tennis.db"
+
+logger = logging.getLogger(__name__)
+
+
+def lookup_player_id(
+    first_name: str,
+    last_name: str,
+    conn: sqlite3.Connection | None = None,
+    manual_map: dict | None = None,
+    fuzzy_cutoff: float = 0.8,
+) -> str | None:
+    """Lookup a player_id by first and last name.
+
+    The search is case-insensitive and will attempt fuzzy matching if an exact
+    match is not found. A manual mapping dictionary can be supplied to handle
+    known name variations.
+
+    Parameters
+    ----------
+    first_name : str
+        Player's first name.
+    last_name : str
+        Player's last name.
+    conn : sqlite3.Connection, optional
+        Database connection. If not provided, a new connection is created using
+        ``DB_PATH`` and closed on exit.
+    manual_map : dict, optional
+        Mapping of ``(first_name.lower(), last_name.lower())`` tuples to
+        ``player_id`` values for manual overrides.
+    fuzzy_cutoff : float, optional
+        Similarity threshold for fuzzy matching (0-1 range).
+
+    Returns
+    -------
+    str | None
+        The corresponding ``player_id`` or ``None`` if no reasonable match is
+        found.
+    """
+    manual_map = manual_map or {}
+    norm_first = first_name.strip().lower()
+    norm_last = last_name.strip().lower()
+
+    # Manual override
+    if (norm_first, norm_last) in manual_map:
+        return manual_map[(norm_first, norm_last)]
+
+    close_conn = False
+    if conn is None:
+        conn = sqlite3.connect(DB_PATH)
+        close_conn = True
+
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT player_id FROM players
+            WHERE lower(first_name) = ? AND lower(last_name) = ?
+            """,
+            (norm_first, norm_last),
+        )
+        rows = cursor.fetchall()
+        if rows:
+            # If multiple matches, return the first one deterministically
+            return rows[0][0]
+
+        # Fuzzy match across all players
+        cursor.execute("SELECT player_id, first_name, last_name FROM players")
+        players = cursor.fetchall()
+        name_to_id = {f"{fn.lower()} {ln.lower()}": pid for pid, fn, ln in players}
+        query = f"{norm_first} {norm_last}"
+        matches = difflib.get_close_matches(
+            query, name_to_id.keys(), n=1, cutoff=fuzzy_cutoff
+        )
+        if matches:
+            return name_to_id[matches[0]]
+    except Exception as exc:
+        logger.error("Error looking up player %s %s: %s", first_name, last_name, exc)
+    finally:
+        if close_conn:
+            conn.close()
+
+    return None


### PR DESCRIPTION
## Summary
- add `lookup_player_id` helper for fuzzy player search
- expose helper via `src.data`
- create simple draw scraping module that uses the helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683caad9f6e4832c98489537b8dc86cd